### PR TITLE
Support Windows

### DIFF
--- a/tool.cabal
+++ b/tool.cabal
@@ -14,7 +14,7 @@ executable tool
   main-is: Main.hs
 
   build-depends: base                  >= 4.8.2.0 && < 4.16
-               , shelly               ^>= 1.9
+               , shelly               ^>= 1.10
                , text                 ^>= 1.2
                , filepath              >= 1.4.2 && < 1.5
                , containers            >= 0.5 && < 0.7


### PR DESCRIPTION
`shelly-1.9` depends on `unix-compat` _and_ `unix`, while `shelly-1.10` only depends on `unix-compat`.
The `unix` package cannot be built under Windows.