### PR TITLE
Support GHC 9.2

### DIFF
--- a/tool.cabal
+++ b/tool.cabal
@@ -13,7 +13,7 @@ executable tool
   hs-source-dirs: src/
   main-is: Main.hs
 
-  build-depends: base                  >= 4.8.2.0 && < 4.16
+  build-depends: base                  >= 4.8.2.0 && < 4.17
                , shelly               ^>= 1.10
                , text                 ^>= 1.2
                , filepath              >= 1.4.2 && < 1.5


### PR DESCRIPTION
This only supports GHC 9.2. I haven't tested anything else.
Alternatively you may want to change the bound to `base < 5` as it [was done last week for `head-hackage-ci`](https://gitlab.haskell.org/ghc/head.hackage/-/blob/master/ci/head-hackage-ci.cabal#L22)